### PR TITLE
Fix: handle when "categories"-item does not exist in localStorage

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -8,8 +8,8 @@ import React, {
   type SetStateAction,
 } from "react";
 import { Role, type Message } from "~/interfaces/message";
-import { type Categories } from "~/pages";
 import { colors } from "~/stitches/colors";
+import { type Categories } from "~/types/categories";
 import { api } from "~/utils/api";
 import MessageList from "./MessageList";
 import QuickAsk from "./QuickAsk";

--- a/src/components/FreudSource/SourceGroup.tsx
+++ b/src/components/FreudSource/SourceGroup.tsx
@@ -55,8 +55,8 @@ const SourceGroup = ({
         </div>
         <div className="flex flex-col">
 
-          {env.NEXT_PUBLIC_NODE_ENV == "development" && sources.map((source) => {
-            return <span>{source.score.toPrecision(3)}</span>
+          {env.NEXT_PUBLIC_NODE_ENV == "development" && sources.map((source, idx) => {
+            return <span key={idx}>{source.score.toPrecision(3)}</span>
           })}
         </div>
         {/* {source.filetype === "pdf" && (

--- a/src/components/SelectCategories.tsx
+++ b/src/components/SelectCategories.tsx
@@ -1,61 +1,62 @@
-
-import React, { FormEvent, useEffect, useState } from 'react'
-import { Categories } from '~/pages';
-import { Checkbox } from './ui/checkbox/Checkbox';
+import React from "react";
+import { type Categories } from "~/pages";
+import { Checkbox } from "./ui/checkbox/Checkbox";
 
 type Props = {
-    categories: Categories;
-    myfunc: React.Dispatch<React.SetStateAction<Categories>>
-}
+  categories: Categories;
+  myfunc: React.Dispatch<React.SetStateAction<Categories>>;
+};
 
 const SelectCategories = ({ categories, myfunc }: Props) => {
-    const onSubmit = (e: FormEvent<HTMLFormElement>) => {
-    }
+  return (
+    <div className="p-10">
+      <h5>
+        Velg hvilke retninger du vil at kildene skal komme fra. Hvis ingen
+        retning er valgt blir alle kildene brukt
+        <br /> <br />
+      </h5>
+      <form action="" className="w-fit">
+        {Object.keys(categories).map((category, index) => {
+          return (
+            <label
+              htmlFor={category}
+              className="flex flex-row justify-between gap-5 pb-2"
+              key={index}
+            >
+              {category}
+              <Checkbox
+                checked={categories[category]}
+                name={category}
+                id={category}
+                onCheckedChange={(checked) => {
+                  if (checked != "indeterminate") {
+                    //Update state and localstore for checkmark
 
+                    const newstate: Categories = {};
 
+                    Object.keys(categories).map((cat) => {
+                      if (cat === category) {
+                        newstate[cat] = checked;
+                      } else {
+                        newstate[cat] = categories[cat]!;
+                      }
+                    });
 
-    return (
-        <div className='p-10'>
-            <h5>
-                Velg hvilke retninger du vil at kildene skal komme fra. Hvis ingen retning er valgt blir alle kildene brukt<br /> <br />
-            </h5>
-            <form action="" onSubmit={onSubmit} className="w-fit">
+                    myfunc(newstate);
 
+                    localStorage.setItem(
+                      "categories",
+                      JSON.stringify(newstate)
+                    );
+                  }
+                }}
+              ></Checkbox>
+            </label>
+          );
+        })}
+      </form>
+    </div>
+  );
+};
 
-                {Object.keys(categories).map((category, index) => {
-                    return (
-                        <label htmlFor={category} className="flex flex-row gap-5 pb-2 justify-between" key={index}>
-                            {category}
-                            <Checkbox checked={categories[category]} name={category} id={category} onCheckedChange={(checked) => {
-
-                                if (checked != "indeterminate") {
-                                    //Update state and localstore for checkmark
-
-                                    let newstate: Categories = {};
-
-                                    Object.keys(categories).map((cat) => {
-                                        if (cat === category) {
-                                            newstate[cat] = checked
-                                        } else {
-                                            newstate[cat] = categories[cat]!
-                                        }
-                                    })
-
-                                    myfunc(newstate);
-
-                                    localStorage.setItem("categories", JSON.stringify(newstate));
-                                }
-
-                            }}></Checkbox>
-                        </label>
-                    )
-                }
-                )
-                }
-
-            </form>
-        </div>
-    )
-}
-
-export default SelectCategories
+export default SelectCategories;

--- a/src/components/SelectCategories.tsx
+++ b/src/components/SelectCategories.tsx
@@ -30,15 +30,19 @@ const SelectCategories = ({ categories, setCategories }: Props) => {
                 id={category}
                 onCheckedChange={(checked) => {
                   if (checked != "indeterminate") {
-                    //Update state and localstore for checkmark
-                    setCategories((categories) => ({
+                    // Define new state
+                    const newState = {
                       ...categories,
                       [category]: checked,
-                    }));
+                    };
 
+                    // Update state
+                    setCategories(newState);
+
+                    // Store state in localStorage
                     localStorage.setItem(
                       "categories",
-                      JSON.stringify(categories)
+                      JSON.stringify(newState)
                     );
                   }
                 }}

--- a/src/components/SelectCategories.tsx
+++ b/src/components/SelectCategories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { type Categories } from "~/pages";
+import { type Categories } from "~/types/categories";
 import { Checkbox } from "./ui/checkbox/Checkbox";
 
 type Props = {

--- a/src/components/SelectCategories.tsx
+++ b/src/components/SelectCategories.tsx
@@ -4,10 +4,10 @@ import { Checkbox } from "./ui/checkbox/Checkbox";
 
 type Props = {
   categories: Categories;
-  myfunc: React.Dispatch<React.SetStateAction<Categories>>;
+  setCategories: React.Dispatch<React.SetStateAction<Categories>>;
 };
 
-const SelectCategories = ({ categories, myfunc }: Props) => {
+const SelectCategories = ({ categories, setCategories }: Props) => {
   return (
     <div className="p-10">
       <h5>
@@ -31,22 +31,14 @@ const SelectCategories = ({ categories, myfunc }: Props) => {
                 onCheckedChange={(checked) => {
                   if (checked != "indeterminate") {
                     //Update state and localstore for checkmark
-
-                    const newstate: Categories = {};
-
-                    Object.keys(categories).map((cat) => {
-                      if (cat === category) {
-                        newstate[cat] = checked;
-                      } else {
-                        newstate[cat] = categories[cat]!;
-                      }
-                    });
-
-                    myfunc(newstate);
+                    setCategories((categories) => ({
+                      ...categories,
+                      [category]: checked,
+                    }));
 
                     localStorage.setItem(
                       "categories",
-                      JSON.stringify(newstate)
+                      JSON.stringify(categories)
                     );
                   }
                 }}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import Head from "next/head";
 import React, { useEffect, useState } from "react";
-import { z } from "zod";
 import Chat from "~/components/Chat";
 import Header from "~/components/Header";
 import SelectCategories from "~/components/SelectCategories";
@@ -8,15 +7,8 @@ import { SidebarFreud } from "~/components/SidebarFreud";
 import { VectorStoreSettings } from "~/components/VectorStoreSettings";
 import { env } from "~/env.mjs";
 import { type Message } from "~/interfaces/message";
+import type { Categories } from "~/types/categories";
 import { api } from "~/utils/api";
-
-
-export const Categories = z.record(
-  z.string(),
-  z.boolean()
-);
-
-export type Categories = z.infer<typeof Categories>;
 
 export default function Home() {
   const [messages, setMessages] = useState<Message[]>([]);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,47 +17,33 @@ export default function Home() {
 
   const fetchedCategories = api.weaviate.listSchemas.useMutation({
     onSuccess: (data) => {
-      //Fetch categories from vector db. Set either false or value from localstore.
       if (!data) {
         throw new Error("Data not defined in OnSuccess");
       }
 
-      const fetched_keys: string[] = [];
+      // If category selections exists in localStorage, update checked value accordingly
+      const localCategorySelections: Categories = JSON.parse(
+        localStorage.getItem("categories") ?? ""
+      ) as Categories;
 
-      data.classes?.forEach((item) => {
-        let name: string;
-        if (!item.class) {
-          name = "Kategori uten navn";
-        } else {
-          name = item.class;
+      // Iterate through classes fetched via API
+      data.classes?.map((item) => {
+        if (item.class === undefined) {
+          return;
         }
-        fetched_keys.push(name);
-      });
 
-      let localstore_categories: { [name: string]: boolean } = {};
-      let localstore_keys: string[] = [];
+        const className = item.class;
+        const localStorageSelectionExists = Object.keys(
+          localCategorySelections
+        ).includes(className);
 
-      localstore_categories = JSON.parse(
-        localStorage.getItem("categories") as string
-      ) as { [name: string]: boolean };
-
-      localstore_keys = Object.keys(
-        localstore_categories
-      );
-
-
-      fetched_keys.map((name) => {
-        if (localstore_keys.includes(name)) {
-          setCategories((prevState) => ({
-            ...prevState,
-            [name]: localstore_categories[name]!,
-          }));
-        } else {
-          setCategories((prevState) => ({
-            ...prevState,
-            [name]: false,
-          }));
-        }
+        // Set to value in localStorage, alternatively default to false (not checked)
+        setCategories((categories) => ({
+          ...categories,
+          [className]: localStorageSelectionExists
+            ? localCategorySelections[className] ?? false
+            : false,
+        }));
       });
     },
   });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -57,7 +57,6 @@ export default function Home() {
             ...prevState,
             [name]: false,
           }));
-
         }
       });
     },
@@ -66,7 +65,6 @@ export default function Home() {
   useEffect(() => {
     fetchedCategories.mutate();
   }, []);
-
 
   return (
     <>
@@ -83,7 +81,10 @@ export default function Home() {
           setShowSettings={setShowSettings}
         >
           <>
-            <SelectCategories categories={categories} myfunc={setCategories} />
+            <SelectCategories
+              categories={categories}
+              setCategories={setCategories}
+            />
             {env.NEXT_PUBLIC_NODE_ENV == "development" && (
               <VectorStoreSettings vectorStoreSchemas={fetchedCategories} />
             )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,7 @@ export default function Home() {
 
       // If category selections exists in localStorage, update checked value accordingly
       const localCategorySelections: Categories = JSON.parse(
-        localStorage.getItem("categories") ?? ""
+        localStorage.getItem("categories") ?? "{}"
       ) as Categories;
 
       // Iterate through classes fetched via API

--- a/src/server/api/routers/langchain.ts
+++ b/src/server/api/routers/langchain.ts
@@ -5,15 +5,14 @@
 import { ConversationalRetrievalQAChain } from "langchain/chains";
 import { OpenAI } from "langchain/llms/openai";
 import { BufferMemory } from "langchain/memory";
+import { type WeaviateStore } from "langchain/vectorstores/weaviate";
 import { z } from "zod";
 import { Message, Role } from "~/interfaces/message";
 import type { Source } from "~/interfaces/source";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
-import { getRetrieverFromIndex } from "~/utils/weaviate/getRetriever";
-
-import { Categories } from "~/pages";
-import { type WeaviateStore } from "langchain/vectorstores/weaviate";
+import { Categories } from "~/types/categories";
 import { MergerRetriever } from "~/utils/weaviate/MergerRetriever";
+import { getRetrieverFromIndex } from "~/utils/weaviate/getRetriever";
 
 // Specify language model, embeddings and prompts
 const model = new OpenAI({

--- a/src/server/api/routers/sourceformat.ts
+++ b/src/server/api/routers/sourceformat.ts
@@ -1,138 +1,130 @@
-import { WeaviateStore } from "langchain/vectorstores/weaviate";
-import { z } from "zod";
-import { Message, Role } from "~/interfaces/message";
-import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
-import { client } from "~/utils/weaviate/client";
-import { embeddings } from "~/utils/weaviate/embeddings";
+import { type WeaviateStore } from "langchain/vectorstores/weaviate";
 import { Configuration, OpenAIApi } from "openai";
-import { Categories } from "~/pages";
-import { Source } from "~/interfaces/source";
+import { z } from "zod";
 import { env } from "~/env.mjs";
-import { getRetrieverFromIndex } from "~/utils/weaviate/getRetriever";
+import { Message, Role } from "~/interfaces/message";
+import { type Source } from "~/interfaces/source";
+import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import { Categories } from "~/types/categories";
 import { MergerRetriever } from "~/utils/weaviate/MergerRetriever";
-import { Content } from "@radix-ui/react-popover";
+import { getRetrieverFromIndex } from "~/utils/weaviate/getRetriever";
 
 const metadataKeys: string[] = [
-    "author",
-    "title",
-    "pageNumber",
-    "loc_lines_from",
-    "loc_lines_to",
+  "author",
+  "title",
+  "pageNumber",
+  "loc_lines_from",
+  "loc_lines_to",
 ];
 
-
-
-
 const configuration = new Configuration({
-    apiKey: env.OPENAI_API_KEY,
+  apiKey: env.OPENAI_API_KEY,
 });
 const openai = new OpenAIApi(configuration);
-
 
 const NUM_SOURCES = 5;
 const SIMILARITY_THRESHOLD = 0.3;
 
-
 export const sourceRouter = createTRPCRouter({
-    ask: publicProcedure
-        .input(z.object({ messages: z.array(Message), categories: Categories }))
-        .mutation(async ({ input }) => {
-            const question = input.messages[input.messages.length - 1]?.content;
+  ask: publicProcedure
+    .input(z.object({ messages: z.array(Message), categories: Categories }))
+    .mutation(async ({ input }) => {
+      const question = input.messages[input.messages.length - 1]?.content;
 
+      if (!question) {
+        throw new Error("Question is undefined");
+      }
 
-            if (!question) {
-                throw new Error("Question is undefined")
-            }
+      const arrayOfActiveCategories: string[] = [];
+      for (const key in input.categories) {
+        if (input.categories[key]) {
+          arrayOfActiveCategories.push(key);
+        }
+      }
 
+      const useAllCategories: boolean = arrayOfActiveCategories.length == 0;
 
-            const arrayOfActiveCategories: string[] = [];
-            for (const key in input.categories) {
-                if (input.categories[key]) {
-                    arrayOfActiveCategories.push(key);
-                }
-            }
+      const arrayOfVectorStores: WeaviateStore[] = [];
+      for (const key in input.categories) {
+        if (input.categories[key] || useAllCategories) {
+          arrayOfVectorStores.push(await getRetrieverFromIndex(key));
+        }
+      }
 
-            const useAllCategories: boolean = arrayOfActiveCategories.length == 0;
+      const retriever = new MergerRetriever(
+        arrayOfVectorStores,
+        NUM_SOURCES,
+        SIMILARITY_THRESHOLD
+      );
 
-            const arrayOfVectorStores: WeaviateStore[] = [];
-            for (const key in input.categories) {
-                if (input.categories[key] || useAllCategories) {
-                    arrayOfVectorStores.push(await getRetrieverFromIndex(key));
-                }
-            }
+      const documents = await retriever.getRelevantDocuments(question);
 
-            const retriever = new MergerRetriever(
-                arrayOfVectorStores,
-                NUM_SOURCES,
-                SIMILARITY_THRESHOLD
-            );
+      // Sort documents for later grouping
+      documents.sort((a, b) => {
+        return a.metadata.title.localeCompare(b.metadata.title);
+      });
 
-            const documents = await retriever.getRelevantDocuments(question)
+      let stuffString = "";
 
-            // Sort documents for later grouping
-            documents.sort((a, b) => { return a.metadata.title.localeCompare(b.metadata.title) })
+      documents.map((doc, index) => {
+        stuffString +=
+          "Source " + (index + 1) + ":\n---\n" + doc.pageContent + "\n---\n\n";
+      });
 
+      const formatedmessages = input.messages.map((message) => {
+        return {
+          role: message.role,
+          content: message.content,
+        };
+      });
 
-            let stuffString = "";
+      const completion = await openai.createChatCompletion({
+        model: "gpt-3.5-turbo",
+        messages: [
+          {
+            role: "system",
+            content: `You are a chatbot used by a professional psychiatrist. They have a work-related question. Only use the ${documents.length} sources below to answer the question, and if the question can't be answered based on the sources, say \"I don't know\". Show usage of each source with in-text citations. Do this with square brackets with ONLY the number of the source. \n\n${stuffString}`,
+          },
+          ...formatedmessages,
+        ],
+        temperature: 0,
+        // stream: true, For streaming: https://github.com/openai/openai-node/discussions/182
+      });
 
-            documents.map(((doc, index) => {
-                stuffString += "Source " + (index + 1) + ":\n---\n" + doc.pageContent + "\n---\n\n"
-            }))
+      const response = completion.data.choices[0]?.message?.content;
 
-            const formatedmessages = input.messages.map((message) => {
-                return {
-                    role: message.role,
-                    content: message.content
-                }
-            })
+      if (!response) {
+        throw new Error("Reply is not defined");
+      }
 
-            const completion = await openai.createChatCompletion({
-                model: "gpt-3.5-turbo",
-                messages: [{ role: "system", content: `You are a chatbot used by a professional psychiatrist. They have a work-related question. Only use the ${documents.length} sources below to answer the question, and if the question can't be answered based on the sources, say \"I don't know\". Show usage of each source with in-text citations. Do this with square brackets with ONLY the number of the source. \n\n${stuffString}` },
-                ...formatedmessages],
-                temperature: 0,
-                // stream: true, For streaming: https://github.com/openai/openai-node/discussions/182
-            });
+      const sources: Source[] = documents.map((source) => {
+        return {
+          content: source.pageContent,
+          author: source.metadata.author,
+          category: source.metadata.category,
+          filename: source.metadata.filename,
+          filetype: source.metadata.filetype,
+          title: source.metadata.title,
+          location: {
+            chapter: source.metadata.chapter,
+            href: source.metadata.href,
+            pageNr: source.metadata.pageNumber,
+            lineFrom: source.metadata.loc_lines_from
+              ? source.metadata.loc_lines_from
+              : 0,
+            lineTo: source.metadata.loc_lines_to
+              ? source.metadata.loc_lines_to
+              : 0,
+          },
+        };
+      });
 
-            const response = completion.data.choices[0]?.message?.content
+      const reply: Message = {
+        role: Role.Assistant,
+        content: response,
+        sources: sources,
+      };
 
-
-            if (!response) {
-                throw new Error("Reply is not defined")
-            }
-
-            const sources: Source[] = documents.map(
-                (source) => {
-                    return {
-                        content: source.pageContent,
-                        author: source.metadata.author,
-                        category: source.metadata.category,
-                        filename: source.metadata.filename,
-                        filetype: source.metadata.filetype,
-                        title: source.metadata.title,
-                        location: {
-                            chapter: source.metadata.chapter,
-                            href: source.metadata.href,
-                            pageNr: source.metadata.pageNumber,
-                            lineFrom: source.metadata.loc_lines_from
-                                ? source.metadata.loc_lines_from
-                                : 0,
-                            lineTo: source.metadata.loc_lines_to
-                                ? source.metadata.loc_lines_to
-                                : 0,
-                        },
-                    };
-                }
-            );
-
-            const reply: Message = {
-                role: Role.Assistant,
-                content: response,
-                sources: sources,
-            };
-
-
-
-            return reply;
-        }),
-})
+      return reply;
+    }),
+});

--- a/src/types/categories.ts
+++ b/src/types/categories.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const Categories = z.record(z.string(), z.boolean());
+
+export type Categories = z.infer<typeof Categories>;


### PR DESCRIPTION
`Object.keys()` failed on `null` object when `localStorage.getItem("categories")` did not exist. This PR is an attempt to handle that situation in a fairly clean way. The core logic is here:

```javascript
/* index.tsx line 24 */
// If category selections exists in localStorage, update checked value accordingly
const localCategorySelections: Categories = JSON.parse(
  localStorage.getItem("categories") ?? "{}"
) as Categories;

// Iterate through classes fetched via API
data.classes?.map((item) => {
  if (item.class === undefined) {
    return;
  }

  const className = item.class;
  const localStorageSelectionExists = Object.keys(
    localCategorySelections
  ).includes(className);

  // Set to value in localStorage, alternatively default to false (not checked)
  setCategories((categories) => ({
    ...categories,
    [className]: localStorageSelectionExists
      ? localCategorySelections[className] ?? false
      : false,
  }));
});
```